### PR TITLE
Additional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 
+debug.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/cypress/integration/Modal.spec.js
+++ b/cypress/integration/Modal.spec.js
@@ -16,11 +16,11 @@ describe("Modal", () => {
 
     it("can be closed by clicking outside of it", () => {
       cy.get("[data-cy=modal]").should("be.visible")
-      cy.get("[data-cy=overlay]").click("left")
+      cy.get("[data-cy=overlay]").click({ force: true })
       cy.get("[data-cy=modal]").should("not.exist")
     })
 
-    it.only("can be closed by hitting 'escape' key", () => {
+    it("can be closed by hitting 'escape' key", () => {
       cy.get("[data-cy=modal]").should("be.visible")
       cy.get("[data-cy=overlay]").trigger("keydown", { keyCode: 27, force: true })
       cy.get("[data-cy=modal]").should("not.exist")
@@ -52,4 +52,20 @@ describe("Modal", () => {
       cy.get("[data-cy=amount]").should("contain", "52 / 250")
     })
   })
+
+  describe("Opening the modal when scrolled down, on low viewport", () => {
+    beforeEach(() => {
+      cy.viewport(1000, 600)
+      cy.get("[data-cy=card]").contains("Chile").scrollIntoView()
+    })
+
+    it("triggers scroll to top, where the modal appears", () => {
+      cy.get("[data-cy=search-field]").topIsNotWithinViewport()
+      cy.get("[data-cy=card]").contains("Chile").click()
+      cy.wait(500)
+      cy.get("[data-cy=modal]").within(() => {
+        cy.get("[data-cy=modal-flag]").isWithinViewport()
+      })
+    })
+  })    
 })

--- a/cypress/integration/searchFunctionality.spec.js
+++ b/cypress/integration/searchFunctionality.spec.js
@@ -37,6 +37,11 @@ describe("Search functionality", () => {
     cy.get("[data-cy=card]").first().should("contain", "Finland")
   })
 
+  it("does not find by native name unless it starts with the search string", () => {
+    cy.get("@input").type("uomi")
+    cy.get("[data-cy=card]").should("have.length", 0)
+  })
+
   it("filters by continent if the exact name is entered", () => {
     cy.get("@input").type("north america")
     cy.get("[data-cy=card]").should("have.length", 41)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --verbose",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jsxBracketSameLine": false
   },
   "devDependencies": {
-    "@types/jest": "^26.0.13",
+    "@types/jest": "^26.0.14",
     "ts-jest": "^26.3.0"
   }
 }

--- a/src/__tests__/sortResult.test.ts
+++ b/src/__tests__/sortResult.test.ts
@@ -9,7 +9,7 @@ const swaziland   = countries[212]
 const sweden      = countries[196]
 const switzerland = countries[42]
 
-it("Finds countries which names start with the string", () => {
+it("Finds countries which names start with the search string", () => {
   expect(findMatchInBeginning(countries, "Sw")).toStrictEqual([
     swaziland, sweden, switzerland
   ])
@@ -24,5 +24,20 @@ it("Is case insensitive", () => {
 it("Finds countries that contains the string, if the string is at least 3 characters", () => {
   expect(findMatchElsewhere(countries, "Swa")).toStrictEqual([
     botswana
+  ])
+})
+
+it("Finds countries based on native name", () => {
+  expect(findMatchInBeginning(countries, "Sver")).toStrictEqual([
+    sweden
+  ])
+})
+
+it("Does not find by native name unless it starts with the search string", () => {
+  expect(findMatchInBeginning(countries, "verige")).not.toStrictEqual([
+    sweden
+  ])
+  expect(findMatchElsewhere(countries, "verige")).not.toStrictEqual([
+    sweden
   ])
 })

--- a/src/helpers/sortResult.ts
+++ b/src/helpers/sortResult.ts
@@ -14,7 +14,7 @@ export const findMatchInBeginning = (array: Country[], filter: string) => {
 
 export const findMatchElsewhere = (array: Country[], filter: string) => {
   filter = filter.toLowerCase()
-  
+
   return filter.length < 3
     ? []
     : array
@@ -22,8 +22,7 @@ export const findMatchElsewhere = (array: Country[], filter: string) => {
           (country) =>
             country.name.toLowerCase().slice(0, filter.length) !== filter &&
             country.native.toLowerCase().slice(0, filter.length) !== filter &&
-            (country.name.toLowerCase().includes(filter) ||
-              country.native.toLowerCase().includes(filter))
+            country.name.toLowerCase().includes(filter)
         )
         .sort((a, b) => a["name"].localeCompare(b["name"]))
 }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,1 @@
 import '@testing-library/jest-dom/extend-expect'
-
-module.exports = {
-  verbose: true,
-};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/extend-expect'
+
+module.exports = {
+  verbose: true,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,10 +1649,18 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@26.x", "@types/jest@^26.0.13":
+"@types/jest@*", "@types/jest@26.x":
   version "26.0.13"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.13.tgz#5a7b9d5312f5dd521a38329c38ee9d3802a0b85e"
   integrity sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
+"@types/jest@^26.0.14":
+  version "26.0.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.14.tgz#078695f8f65cb55c5a98450d65083b2b73e5a3f3"
+  integrity sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"


### PR DESCRIPTION
### Adding assertions:
* When on a low viewport, and scrolled down, the window should automatically scroll to top, where the modal appears with `position: absolute`
* Search by native name should not apply if it doesn't start with the search string
This behaviour is corrected and enforced in this PR
